### PR TITLE
increase delay in script

### DIFF
--- a/src/app/providers/electron.service.ts
+++ b/src/app/providers/electron.service.ts
@@ -67,7 +67,7 @@ export class ElectronService {
 
     const cmd = `
               start "" "${path}" /n
-              ${this.pathToNircmd} wait 1000
+              ${this.pathToNircmd} wait 2000
               ${this.pathToNircmd} win setsize foreground  ${x} ${y} ${width} ${height}
               `;
 


### PR DESCRIPTION
slows down performance, but it's necessary until a setting corresponding to wait time is implemented